### PR TITLE
feat: support mocking private methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
-N/A
+### Added
+
+* Support for mocking private instance and class methods
+
+### Fixed
+
+* When mocking protected methods, the method now remains protected while mocked and after unmocking
 
 ## [1.1.0](https://github.com/clarkedb/grift/releases/tag/v1.1.0) - 2022-02-03
 
@@ -15,14 +21,6 @@ This version adds support for Ruby 3.1 and updates various dependencies.
 ### Added
 
 * Support Ruby 3.1
-
-### Updated
-
-* Updates `minitest`
-* Updates `minitest-reporters`
-* Updates `rubocop`
-* Updates `rubocop-minitest`
-* Updates `rubocop-performance`
 
 ## [1.0.2](https://github.com/clarkedb/grift/releases/tag/v1.0.2) - 2021-11-11
 

--- a/grift.gemspec
+++ b/grift.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "A gem for simple mocking and spying in Ruby's MiniTest framework."
   spec.homepage      = 'https://github.com/clarkedb/grift'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
   spec.metadata = {
     'bug_tracker_uri' => "#{spec.homepage}/issues",

--- a/test/target.rb
+++ b/test/target.rb
@@ -26,7 +26,25 @@ class Target
     !@secrets.empty?
   end
 
-  def self.mimic(target)
-    Target.new(first_name: target.first_name, last_name: target.last_name, gullible: false)
+  def change_name(first_name: nil, last_name: nil)
+    @first_name = first_name if first_name
+    @last_name = last_name if last_name
+  end
+
+  def self.mimic(target, gullible: false)
+    Target.new(first_name: target.first_name, last_name: target.last_name, gullible: gullible)
+  end
+
+  protected
+
+  def gullible?
+    @gullible
+  end
+
+  private
+
+  def wipe_memory
+    @knowledge = []
+    @secrets = []
   end
 end


### PR DESCRIPTION
Closes #65 by allowing private methods to be mocked. Also fixes #66 and ensures that the same applies to newly mockable private methods.

The way this is implemented leads to Grift dropping support for [Ruby 2.5 which has been EOL for a year now](https://www.ruby-lang.org/en/downloads/branches/).