### PR TITLE
fix: keep ancestor definition on inherited method unmock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Changed
+
+* Dropped support for Ruby 2.5
+
 ### Added
 
 * Support for mocking private instance and class methods
@@ -13,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 * When mocking protected methods, the method now remains protected while mocked and after unmocking
+* When mocking inherited methods, the method goes back to the ancestor's definition after unmocking
 
 ## [1.1.0](https://github.com/clarkedb/grift/releases/tag/v1.1.0) - 2022-02-03
 

--- a/test/grift/mock_method_test.rb
+++ b/test/grift/mock_method_test.rb
@@ -321,4 +321,16 @@ class MockMethodTest < Minitest::Test
     private_mock.mock_restore
     assert Target.private_method_defined?(:wipe_memory), 'Expected method to be private after unmocking'
   end
+
+  def test_it_mocks_inherited_methods
+    mark = Mark.new(first_name: 'Charles', last_name: 'Boyle')
+    refute Mark.method_defined?(:full_name, false)
+    assert Mark.method_defined?(:full_name, true)
+    full_name_mock = Grift::MockMethod.new(Mark, :full_name).mock_return_value('Jake Peralta')
+    assert Mark.method_defined?(:full_name, false), 'Expected method to be defined by child after mocking'
+    assert_equal 'Jake Peralta', mark.full_name
+    full_name_mock.mock_restore
+    refute Mark.method_defined?(:full_name, false), 'Expected method not to be defined by child after unmocking'
+    assert Mark.method_defined?(:full_name, true), 'Expected method to be defined by an ancestor after unmocking'
+  end
 end

--- a/test/mark.rb
+++ b/test/mark.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+##
+# A class to mock for testing Grift
+#
+class Mark < Target
+  attr_reader :status
+
+  def initialize(first_name: 'Tobias', last_name: 'Funke', gullible: true, secrets: [])
+    super
+
+    @status = 0
+  end
+
+  def upgrade(increase = 1)
+    @status += increase
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,6 +29,7 @@ Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
 # classes for mock tests
 require 'target'
+require 'mark'
 
 # rubocop:disable Style/ClassAndModuleChildren
 class Minitest::Test


### PR DESCRIPTION
Closes #67 by tracking if method definition was originally inherited from an ancestor and only restoring the method in an unmock if it wasn't inherited.