### PR TITLE
fix: cannot watch methods with kwargs in ruby 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-* Dropped support for Ruby 2.5
+* Dropped support for Ruby 2.5 and Ruby 2.6
+* To support keyword arguments, records of call arguments are no longer stored in simple arrays but in a custom Enumerable
+  + This changes the way that your tests will interact with mock calls
+  + When before `calls` returned an array, it returns a `Grift::MockMethod::MockExecutions::MockArguments` object
+  + Migrating to maintain previous behavior just requires appending `.args` to `calls`
 
 ### Added
 
 * Support for mocking private instance and class methods
+* Support for mocking methods that take positional and keyword arguments
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,22 @@ my_spy.mock_implementation do |arg1, arg2|
 end
 ```
 
+or for a method taking keyword arguments:
+
+```ruby
+my_spy = Grift.spy_on(MyClass, :my_method)
+my_spy.mock_implementation do |arg1, arg2, **kwargs|
+    x = do_something(arg1, arg2, kwargs[:arg3], kwargs[:arg4])
+    do_something_else(x) # the last line will be returned
+end
+
 ### Chaining
 
 You can chain `mock_return_value` and `mock_implementation` after initializing the mock.
 
 ```ruby
-my_mock = Grift.spy_on(MyClass, :my_method).mock_implementation do |*args|
-    do_something(*args)
+my_mock = Grift.spy_on(MyClass, :my_method).mock_implementation do |*args, **kwargs|
+    do_something(*args, **kwargs)
 end
 #=> Grift::MockMethod object is returned
 ```
@@ -99,8 +108,12 @@ my_mock.mock.count
 #=> 2
 
 # get args for each call to the method while mocked
-my_mock.mock.calls
-#=> [['first_arg1', 'second_arg1'], ['first_arg2', 'second_arg2']]
+my_mock.mock.calls[0].args
+#=> ['first_arg1', 'second_arg1']
+
+# get kwargs for each call to the method while mocked
+my_mock.mock.calls[0].kwargs
+#=> { first_arg1: 'value' }
 
 # get results (return value) for each call to the method while mocked
 my_mock.mock.results
@@ -109,7 +122,7 @@ my_mock.mock.results
 
 ## Requirements
 
-Grift supports all Ruby versions >= 2.5 (including 3.1).
+Grift supports all Ruby versions >= 2.7 (including 3.1).
 
 ## Development
 
@@ -119,7 +132,7 @@ When developing, to install Grift whith your changes onto your local machine, ru
 
 ### Docs
 
-The docs are generated using YARD. To build the docs, first `gem install yard`. Then run `yardoc` to build the new docs. This is always done before a release to update the docs that get published and made available with the gem.
+The docs are generated using YARD. To build the docs, first `gem install yard` . Then run `yardoc` to build the new docs. This is always done before a release to update the docs that get published and made available with the gem.
 
 ## Contributing
 

--- a/grift.gemspec
+++ b/grift.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "A gem for simple mocking and spying in Ruby's MiniTest framework."
   spec.homepage      = 'https://github.com/clarkedb/grift'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 
   spec.metadata = {
     'bug_tracker_uri' => "#{spec.homepage}/issues",

--- a/lib/grift.rb
+++ b/lib/grift.rb
@@ -5,6 +5,7 @@ require 'grift/error'
 require 'grift/minitest_plugin'
 require 'grift/mock_method'
 require 'grift/mock_method/mock_executions'
+require 'grift/mock_method/mock_executions/mock_arguments'
 require 'grift/mock_store'
 require 'grift/version'
 

--- a/lib/grift/mock_method.rb
+++ b/lib/grift/mock_method.rb
@@ -138,11 +138,11 @@ module Grift
       mock_executions = @mock_executions # required to access inside class instance block
 
       class_instance.remove_method(@method_name) if !@inherited && method_defined?
-      class_instance.define_method @method_name do |*args|
-        return_value = yield(*args)
+      class_instance.define_method @method_name do |*args, **kwargs|
+        return_value = yield(*args, **kwargs)
 
         # record the args passed in the call to the method and the result
-        mock_executions.store(args, return_value)
+        mock_executions.store(args: args, result: return_value)
         return return_value
       end
       class_instance.send(@method_access, @method_name)
@@ -170,9 +170,9 @@ module Grift
       mock_executions = @mock_executions # required to access inside class instance block
 
       class_instance.remove_method(@method_name) if !@inherited && method_defined?
-      class_instance.define_method @method_name do |*args|
+      class_instance.define_method @method_name do |*args, **kwargs|
         # record the args passed in the call to the method and the result
-        mock_executions.store(args, return_value)
+        mock_executions.store(args: args, kwargs: kwargs, result: return_value)
         return return_value
       end
       class_instance.send(@method_access, @method_name)
@@ -220,11 +220,11 @@ module Grift
       cache_method_name = @cache_method_name
 
       class_instance.remove_method(@method_name) if !@inherited && method_defined?
-      class_instance.define_method @method_name do |*args|
-        return_value = send(cache_method_name, *args)
+      class_instance.define_method @method_name do |*args, **kwargs|
+        return_value = send(cache_method_name, *args, **kwargs)
 
         # record the args passed in the call to the method and the result
-        mock_executions.store(args, return_value)
+        mock_executions.store(args: args, kwargs: kwargs, result: return_value)
         return return_value
       end
       class_instance.send(@method_access, @method_name)

--- a/lib/grift/mock_method.rb
+++ b/lib/grift/mock_method.rb
@@ -131,7 +131,7 @@ module Grift
     #   MyClass.my_method(1, 2)
     #   #=> [2, 1]
     #
-    # @return [Grift::MockMethod] the mock itself
+    # @return [self] the mock itself
     #
     def mock_implementation(*)
       premock_setup
@@ -163,7 +163,7 @@ module Grift
     #
     # @param return_value the value to return from the method
     #
-    # @return [Grift::MockMethod] the mock itself
+    # @return [self] the mock itself
     #
     def mock_return_value(return_value = nil)
       premock_setup
@@ -212,7 +212,7 @@ module Grift
     ##
     # Watches the method without mocking its impelementation or return value.
     #
-    # @return [Grift::MockMethod] the mock itself
+    # @return [self] the mock itself
     #
     def watch_method
       premock_setup

--- a/lib/grift/mock_method.rb
+++ b/lib/grift/mock_method.rb
@@ -125,11 +125,11 @@ module Grift
     #   #=> '7'
     #
     # @example
-    #   my_mock = Grift.spy_on(MyClass, :my_method).mock_implementation do |first, second|
-    #       [second, first]
+    #   my_mock = Grift.spy_on(MyClass, :my_method).mock_implementation do |first, second, **kwargs|
+    #       [second, kwargs[:third], first]
     #   end
-    #   MyClass.my_method(1, 2)
-    #   #=> [2, 1]
+    #   MyClass.my_method(1, 2, third: 3)
+    #   #=> [2, 3, 1]
     #
     # @return [self] the mock itself
     #

--- a/lib/grift/mock_method/mock_executions.rb
+++ b/lib/grift/mock_method/mock_executions.rb
@@ -89,16 +89,17 @@ module Grift
       # Stores an args and result pair to the executions array.
       #
       # @example
-      #   mock_store = Grift::MockMethod::MockExecutions.new
-      #   mock_store.store([1, 1], [2])
+      #   mock_executions = Grift::MockMethod::MockExecutions.new
+      #   mock_executions.store(args: [1, 1], kwargs: { test: true }, result: 2)
       #
-      # @param args [Array] the args to store
+      # @param args [Array] the postitional args to store
+      # @param kwargs [Hash] the keyword args to store
       # @param result the method result to store
       #
       # @return [Array] an updated array of executions
       #
-      def store(args, result)
-        @executions.push({ arguments: MockArguments.new(args: args), result: result })
+      def store(args: [], kwargs: {}, result: nil)
+        @executions.push({ arguments: MockArguments.new(args: args, kwargs: kwargs), result: result })
       end
     end
   end

--- a/lib/grift/mock_method/mock_executions.rb
+++ b/lib/grift/mock_method/mock_executions.rb
@@ -9,7 +9,7 @@ module Grift
       ##
       # A new instance of MockExecutions.
       #
-      # @return [Grift::MockMethod::MockExectuions]
+      # @return [Grift::MockMethod::MockExecutions]
       #
       def initialize
         @executions = []
@@ -21,14 +21,14 @@ module Grift
       # @example
       #   my_mock = Grift.spy_on(Number, :+)
       #   x = (3 + 4) + 5
-      #   my_mock.mock.calls
+      #   my_mock.mock.calls.map(&:values)
       #   #=> [[4], [5]]
       #
-      # @return [Array<Array>] an array of arrays of args
+      # @return [Array<Grift::MockMethod::MockExecutions::MockArguments>] an array of MockArguments
       #
       def calls
         @executions.map do |exec|
-          exec[:args]
+          exec[:arguments]
         end
       end
 
@@ -92,10 +92,13 @@ module Grift
       #   mock_store = Grift::MockMethod::MockExecutions.new
       #   mock_store.store([1, 1], [2])
       #
-      # @return [Array] an array of results
+      # @param args [Array] the args to store
+      # @param result the method result to store
+      #
+      # @return [Array] an updated array of executions
       #
       def store(args, result)
-        @executions.push({ args: args, result: result })
+        @executions.push({ arguments: MockArguments.new(args: args), result: result })
       end
     end
   end

--- a/lib/grift/mock_method/mock_executions/mock_arguments.rb
+++ b/lib/grift/mock_method/mock_executions/mock_arguments.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+module Grift
+  class MockMethod
+    class MockExecutions
+      ##
+      # An immutable Enumerable that stores the arguments used in a call for {Grift::MockMethod::MockExecutions}.
+      #
+      class MockArguments
+        include Enumerable
+
+        attr_reader :args, :kwargs
+
+        ##
+        # A new instance of MockArguments.
+        #
+        # @return [Grift::MockMethod::MockExecutions::MockArguments]
+        #
+        def initialize(args: [], kwargs: {})
+          @args = args.freeze
+          @kwargs = kwargs.freeze
+        end
+
+        ##
+        # Retrieves a stored argument by an accessor. For positional arguments this would be an integer
+        # corresponding to the arguments position in the method call signature. For keyword arguments
+        # this would be the key / parameter name as a symbol or string.
+        #
+        # @example
+        #   my_mock = Grift.mock(Request, :new)
+        #   request = Request.new('/users', method: 'GET')
+        #   #=> <Request object>
+        #   my_mock.mock.calls.last[0] # integer access for positional
+        #   #=> '/users'
+        #   my_mock.mock.calls.last[:method] # key access for keyword
+        #   #=> 'GET'
+        #
+        # @param index [Integer, Symbol, String] the accessor for the desired argument
+        #
+        # @raise [Grift::Error] exception if accessor is not a supported type
+        #
+        # @return the specified value
+        #
+        def [](index)
+          if index.instance_of?(Integer)
+            @args[index]
+          elsif index.instance_of?(Symbol)
+            @kwargs[index]
+          elsif index.instance_of?(String)
+            @kwargs[index.to_sym]
+          else
+            raise(Grift::Error, "Cannot access by type '#{index.class}'. Expected an Integer, Symbol, or String")
+          end
+        end
+
+        ##
+        # Calls the given block once for each argument value, passing that value
+        # as a parameter.
+        #
+        # @return [void]
+        #
+        def each(&block)
+          @args.each(&block)
+          @kwargs.each_value(&block)
+        end
+
+        ##
+        # @see Enumerable#first
+        #
+        # Returns the last argument passed in the call.
+        #
+        # @example
+        #   my_mock = Grift.mock(Request, :new)
+        #   request = Request.new('/users', method: 'GET')
+        #   #=> <Request object>
+        #   my_mock.mock.calls.last.last
+        #   #=> 'GET'
+        #
+        # @return [Any]
+        #
+        def last
+          @args.last || @kwargs.values.last
+        end
+
+        ##
+        # Returns the number of arguments passed in the call.
+        #
+        # @example
+        #   arr = [1, 2, 3]
+        #   my_mock = Grift.mock(Array, :count)
+        #   arr.count
+        #   #=> 3
+        #   my_mock.mock.calls.last.length
+        #   #=> 0
+        #   arr.count(3)
+        #   #=> 1
+        #   my_mock.mock.calls.last.length
+        #   #=> 1
+        #
+        # @return [Integer]
+        #
+        def length
+          @args.length + @kwargs.length
+        end
+
+        ##
+        # Returns true if the call included no arguments.
+        #
+        # @example
+        #   arr = [1, 2, 3]
+        #   my_mock = Grift.mock(Array, :count)
+        #   arr.count
+        #   #=> 3
+        #   my_mock.mock.calls.last.empty?
+        #   #=> true
+        #   arr.count(2)
+        #   #=> 1
+        #   my_mock.mock.calls.last.empty?
+        #   #=> false
+        #
+        # @return [Boolean] true if the no arguments were used
+        #
+        def empty?
+          @args.empty? && @kwargs.empty?
+        end
+
+        ##
+        # Returns the keyword parameter keys passed in the call.
+        #
+        # To get the values, use {Grift::MockMethod::MockExecutions::MockArguments#values}.
+        #
+        # @example
+        #   my_mock = Grift.mock(Request, :new)
+        #   request = Request.new('/users', method: 'GET')
+        #   #=> <Request object>
+        #   my_mock.mock.calls.last.keys
+        #   #=> [:method]
+        #
+        # @return [Array<Symbol>] the parameter keys
+        #
+        def keys
+          @kwargs.keys
+        end
+
+        ##
+        # Returns the arguments passed in the call.
+        #
+        # If a keyword argument was used, then only the value will be returned.
+        # To get the keys, use {Grift::MockMethod::MockExecutions::MockArguments#keys}.
+        #
+        # @example
+        #   my_mock = Grift.mock(Request, :new)
+        #   request = Request.new('/users', method: 'GET')
+        #   #=> <Request object>
+        #   my_mock.mock.calls.last.keys
+        #   #=> [:method]
+        #
+        # @return [Array] the argument values
+        #
+        def values
+          @args + @kwargs.values
+        end
+      end
+    end
+  end
+end

--- a/test/grift/mock_method/mock_executions/mock_arguments_test.rb
+++ b/test/grift/mock_method/mock_executions/mock_arguments_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MockArgumentsTest < Minitest::Test
+  def test_it_includes_enumerable
+    mock_arguments = Grift::MockMethod::MockExecutions::MockArguments.new
+    assert_kind_of Enumerable, mock_arguments
+  end
+
+  def test_it_implements_each
+    mock_arguments = Grift::MockMethod::MockExecutions::MockArguments.new
+    assert_respond_to mock_arguments, :each
+  end
+
+  def test_it_can_access_keyword_argument_by_symbol
+    kwargs = { argument_one: 'one', argument_two: 'two' }
+    mock_arguments = Grift::MockMethod::MockExecutions::MockArguments.new(kwargs: kwargs)
+    assert_nil mock_arguments[0]
+    kwargs.each_key do |key|
+      assert_equal kwargs[key], mock_arguments[key]
+      assert_equal kwargs[key], mock_arguments[key.to_s]
+    end
+  end
+
+  def test_it_can_access_positional_argument_by_index
+    args = %w[it works great]
+    mock_arguments = Grift::MockMethod::MockExecutions::MockArguments.new(args: args)
+    assert_nil mock_arguments['0']
+    args.length.times.each do |i|
+      assert_equal args[i], mock_arguments[i]
+    end
+  end
+
+  def test_raises_error_when_attempting_bracket_access_with_unknown_type
+    mock_arguments = Grift::MockMethod::MockExecutions::MockArguments.new
+    assert_raises Grift::Error do
+      mock_arguments[{ a_hash: 'is not valid' }]
+    end
+  end
+
+  def test_it_returns_correct_values_for_first_and_last_with_keyword_args
+    kwargs = { test_1: 'first', test_2: 'middle', test_3: 'last' }
+    mock_arguments = Grift::MockMethod::MockExecutions::MockArguments.new(kwargs: kwargs)
+    assert_equal kwargs[:test_1], mock_arguments.first
+    assert_equal kwargs[:test_3], mock_arguments.last
+  end
+
+  def test_it_returns_correct_values_for_first_and_last_with_positional_args
+    args = %w[first is not last]
+    mock_arguments = Grift::MockMethod::MockExecutions::MockArguments.new(args: args)
+    assert_equal args.first, mock_arguments.first
+    assert_equal args.last, mock_arguments.last
+  end
+
+  def test_it_returns_correct_values_for_first_and_last_with_blended_args
+    args = %w[first is not last]
+    kwargs = { test_1: 'first', test_2: 'middle', test_3: 'last' }
+    mock_arguments = Grift::MockMethod::MockExecutions::MockArguments.new(args: args, kwargs: kwargs)
+    assert_equal args.first, mock_arguments.first
+    assert_equal kwargs[:test_3], mock_arguments.last
+  end
+
+  def test_it_computes_correct_length
+    args = (0..5).to_a
+    kwargs = { test_1: 'test', test_2: 'test' }
+    mock_arguments = Grift::MockMethod::MockExecutions::MockArguments.new(args: args, kwargs: kwargs)
+    assert_equal args.length + kwargs.length, mock_arguments.length
+  end
+
+  def test_it_determines_empty_accurately
+    assert_empty Grift::MockMethod::MockExecutions::MockArguments.new
+    refute_empty Grift::MockMethod::MockExecutions::MockArguments.new(args: ['test'])
+  end
+
+  def test_it_returns_positional_argument_keys
+    args = (0..5).to_a
+    kwargs = { test_1: 'test', test_2: 'test' }
+    mock_arguments = Grift::MockMethod::MockExecutions::MockArguments.new(args: args, kwargs: kwargs)
+    assert_equal %i[test_1 test_2], mock_arguments.keys
+  end
+
+  def test_it_returns_all_values
+    args = (0..5).to_a
+    kwargs = { test_1: 'test', test_2: 'test' }
+    mock_arguments = Grift::MockMethod::MockExecutions::MockArguments.new(args: args, kwargs: kwargs)
+    expected_values = args + kwargs.values
+    assert_equal expected_values, mock_arguments.values
+  end
+end

--- a/test/grift/mock_method/mock_executions_test.rb
+++ b/test/grift/mock_method/mock_executions_test.rb
@@ -15,12 +15,14 @@ class MockExecutionsTest < Minitest::Test
     assert_empty executions
 
     args = %w[what is the answer?]
+    kwargs = { test: true }
     result = 42
-    executions.store(args, result)
+    executions.store(args: args, kwargs: kwargs, result: result)
     refute_empty executions
     assert_equal 1, executions.count
 
     assert_equal result, executions.results.first
     assert_equal args, executions.calls.first.args
+    assert_equal kwargs, executions.calls.first.kwargs
   end
 end

--- a/test/grift/mock_method/mock_executions_test.rb
+++ b/test/grift/mock_method/mock_executions_test.rb
@@ -21,6 +21,6 @@ class MockExecutionsTest < Minitest::Test
     assert_equal 1, executions.count
 
     assert_equal result, executions.results.first
-    assert_equal args, executions.calls.first
+    assert_equal args, executions.calls.first.args
   end
 end

--- a/test/grift/mock_method_test.rb
+++ b/test/grift/mock_method_test.rb
@@ -113,7 +113,7 @@ class MockMethodTest < Minitest::Test
     assert_equal expected_full_name_result, full_name_mock.mock.results.first
   end
 
-  def test_it_mocks_an_class_method_implementation
+  def test_it_mocks_a_class_method_implementation
     target = Target.new(first_name: 'Jerry')
     assert_respond_to Target, :mimic
     assert_equal target.first_name, Target.mimic(target).first_name
@@ -127,7 +127,7 @@ class MockMethodTest < Minitest::Test
     expected_mimic_result = target.full_name * 2
     assert_equal expected_mimic_result, mocked_result
 
-    assert_equal [target], mimic_mock.mock.calls.first
+    assert_equal [target], mimic_mock.mock.calls.first.args
     assert_equal expected_mimic_result, mimic_mock.mock.results.first
   end
 

--- a/test/grift/mock_method_test.rb
+++ b/test/grift/mock_method_test.rb
@@ -354,7 +354,7 @@ class MockMethodTest < Minitest::Test
     assert_nil target.change_name(last_name: 'Howard')
     refute_equal 'Howard', target.last_name
     refute_empty change_name_mock.mock.calls
-    assert_equal({ last_name: 'Howard' }, change_name_mock.mock.calls.last.last)
+    assert_equal({ last_name: 'Howard' }, change_name_mock.mock.calls.last.kwargs)
   end
 
   def test_it_mocks_a_method_implementation_with_keyword_arguments
@@ -365,7 +365,7 @@ class MockMethodTest < Minitest::Test
     refute_nil target.change_name(last_name: 'Howard')
     refute_equal 'Howard', target.last_name
     refute_empty change_name_mock.mock.calls
-    assert_equal({ last_name: 'Howard' }, change_name_mock.mock.calls.last.last)
+    assert_equal({ last_name: 'Howard' }, change_name_mock.mock.calls.last.kwargs)
   end
 
   def test_it_watches_a_method_with_keyword_arguments
@@ -374,7 +374,7 @@ class MockMethodTest < Minitest::Test
     target.change_name(last_name: 'Howard')
     assert_equal 'Howard', target.last_name
     refute_empty change_name_mock.mock.calls
-    assert_equal({ last_name: 'Howard' }, change_name_mock.mock.calls.last.last)
+    assert_equal({ last_name: 'Howard' }, change_name_mock.mock.calls.last.kwargs)
   end
 
   def test_it_mocks_a_method_return_value_with_blended_argument_types
@@ -382,8 +382,8 @@ class MockMethodTest < Minitest::Test
     mimic_mock = Grift::MockMethod.new(Target, :mimic).mock_return_value
     assert_nil Target.mimic(target, gullible: true)
     refute_empty mimic_mock.mock.calls
-    assert_equal target, mimic_mock.mock.calls.last.first
-    assert_equal({ gullible: true }, mimic_mock.mock.calls.last.last)
+    assert_equal target, mimic_mock.mock.calls.last.args.first
+    assert_equal({ gullible: true }, mimic_mock.mock.calls.last.kwargs)
   end
 
   def test_it_mocks_a_method_implementation_with_blended_argument_types
@@ -393,8 +393,8 @@ class MockMethodTest < Minitest::Test
     end
     assert_equal 'Hannon', Target.mimic(target, gullible: true)
     refute_empty mimic_mock.mock.calls
-    assert_equal target, mimic_mock.mock.calls.last.first
-    assert_equal({ gullible: true }, mimic_mock.mock.calls.last.last)
+    assert_equal target, mimic_mock.mock.calls.last.args.first
+    assert_equal({ gullible: true }, mimic_mock.mock.calls.last.kwargs)
   end
 
   def test_it_watches_a_method_with_blended_arguments_types
@@ -403,7 +403,7 @@ class MockMethodTest < Minitest::Test
     target_mimic = Target.mimic(target, gullible: true)
     assert target_mimic.gullible
     refute_empty mimic_mock.mock.calls
-    assert_equal target, mimic_mock.mock.calls.last.first
-    assert_equal({ gullible: true }, mimic_mock.mock.calls.last.last)
+    assert_equal target, mimic_mock.mock.calls.last.args.first
+    assert_equal({ gullible: true }, mimic_mock.mock.calls.last.kwargs)
   end
 end

--- a/test/grift/mock_method_test.rb
+++ b/test/grift/mock_method_test.rb
@@ -244,11 +244,13 @@ class MockMethodTest < Minitest::Test
     target = Target.new(gullible: false)
     refute target.send(:gullible?)
     assert Target.protected_method_defined?(:gullible?)
+
     protected_mock = Grift::MockMethod.new(Target, :gullible?)
     assert_equal :protected, protected_mock.method_access
     assert Target.protected_method_defined?(:gullible?), 'Expected method to be protected after mocking'
     refute target.send(:gullible?)
     refute_empty protected_mock.mock
+
     protected_mock.mock_restore
     assert Target.protected_method_defined?(:gullible?), 'Expected method to be protected after unmocking'
   end
@@ -257,12 +259,14 @@ class MockMethodTest < Minitest::Test
     target = Target.new(secrets: ['the password is 1234'])
     assert target.knows_secrets?
     assert Target.private_method_defined?(:wipe_memory)
+
     private_mock = Grift::MockMethod.new(Target, :wipe_memory)
     assert_equal :private, private_mock.method_access
     assert Target.private_method_defined?(:wipe_memory), 'Expected method to be private after mocking'
     target.send(:wipe_memory)
     refute target.knows_secrets?
     refute_empty private_mock.mock
+
     private_mock.mock_restore
     assert Target.private_method_defined?(:wipe_memory), 'Expected method to be private after unmocking'
   end
@@ -271,10 +275,12 @@ class MockMethodTest < Minitest::Test
     target = Target.new(gullible: false)
     refute target.send(:gullible?)
     assert Target.protected_method_defined?(:gullible?)
+
     protected_mock = Grift::MockMethod.new(Target, :gullible?).mock_return_value(true)
     assert_equal :protected, protected_mock.method_access
     assert Target.protected_method_defined?(:gullible?), 'Expected method to be protected after mocking'
     assert target.send(:gullible?)
+
     protected_mock.mock_restore
     assert Target.protected_method_defined?(:gullible?), 'Expected method to be protected after unmocking'
   end
@@ -283,11 +289,13 @@ class MockMethodTest < Minitest::Test
     target = Target.new(secrets: ['the password is 1234'])
     assert target.knows_secrets?
     assert Target.private_method_defined?(:wipe_memory)
+
     private_mock = Grift::MockMethod.new(Target, :wipe_memory).mock_return_value
     assert_equal :private, private_mock.method_access
     assert Target.private_method_defined?(:wipe_memory), 'Expected method to be private after mocking'
     assert_nil target.send(:wipe_memory)
     assert target.knows_secrets?
+
     private_mock.mock_restore
     assert Target.private_method_defined?(:wipe_memory), 'Expected method to be private after unmocking'
   end
@@ -296,12 +304,14 @@ class MockMethodTest < Minitest::Test
     target = Target.new(gullible: false)
     refute target.send(:gullible?)
     assert Target.protected_method_defined?(:gullible?)
+
     protected_mock = Grift::MockMethod.new(Target, :gullible?).mock_implementation do
       return true
     end
     assert_equal :protected, protected_mock.method_access
     assert Target.protected_method_defined?(:gullible?), 'Expected method to be protected after mocking'
     assert target.send(:gullible?)
+
     protected_mock.mock_restore
     assert Target.protected_method_defined?(:gullible?), 'Expected method to be protected after unmocking'
   end
@@ -310,6 +320,7 @@ class MockMethodTest < Minitest::Test
     target = Target.new(secrets: ['the password is 1234'], gullible: true)
     assert target.knows_secrets?
     assert Target.private_method_defined?(:wipe_memory)
+
     private_mock = Grift::MockMethod.new(Target, :wipe_memory).mock_implementation do
       target.convince('the password is wrong')
     end
@@ -318,6 +329,7 @@ class MockMethodTest < Minitest::Test
     target.send(:wipe_memory)
     assert target.knows_secrets?
     assert_equal ['the password is wrong'], target.knowledge
+
     private_mock.mock_restore
     assert Target.private_method_defined?(:wipe_memory), 'Expected method to be private after unmocking'
   end
@@ -326,11 +338,72 @@ class MockMethodTest < Minitest::Test
     mark = Mark.new(first_name: 'Charles', last_name: 'Boyle')
     refute Mark.method_defined?(:full_name, false)
     assert Mark.method_defined?(:full_name, true)
+
     full_name_mock = Grift::MockMethod.new(Mark, :full_name).mock_return_value('Jake Peralta')
     assert Mark.method_defined?(:full_name, false), 'Expected method to be defined by child after mocking'
     assert_equal 'Jake Peralta', mark.full_name
+
     full_name_mock.mock_restore
     refute Mark.method_defined?(:full_name, false), 'Expected method not to be defined by child after unmocking'
     assert Mark.method_defined?(:full_name, true), 'Expected method to be defined by an ancestor after unmocking'
+  end
+
+  def test_it_mocks_a_method_return_value_with_keyword_arguments
+    target = Target.new(first_name: 'Kelly', last_name: 'Kapoor')
+    change_name_mock = Grift::MockMethod.new(Target, :change_name).mock_return_value
+    assert_nil target.change_name(last_name: 'Howard')
+    refute_equal 'Howard', target.last_name
+    refute_empty change_name_mock.mock.calls
+    assert_equal({ last_name: 'Howard' }, change_name_mock.mock.calls.last.last)
+  end
+
+  def test_it_mocks_a_method_implementation_with_keyword_arguments
+    target = Target.new(first_name: 'Kelly', last_name: 'Kapoor')
+    change_name_mock = Grift::MockMethod.new(Target, :change_name).mock_implementation do |*_args|
+      return target.full_name
+    end
+    refute_nil target.change_name(last_name: 'Howard')
+    refute_equal 'Howard', target.last_name
+    refute_empty change_name_mock.mock.calls
+    assert_equal({ last_name: 'Howard' }, change_name_mock.mock.calls.last.last)
+  end
+
+  def test_it_watches_a_method_with_keyword_arguments
+    target = Target.new(first_name: 'Kelly', last_name: 'Kapoor')
+    change_name_mock = Grift::MockMethod.new(Target, :change_name)
+    target.change_name(last_name: 'Howard')
+    assert_equal 'Howard', target.last_name
+    refute_empty change_name_mock.mock.calls
+    assert_equal({ last_name: 'Howard' }, change_name_mock.mock.calls.last.last)
+  end
+
+  def test_it_mocks_a_method_return_value_with_blended_argument_types
+    target = Target.new(first_name: 'Erin', last_name: 'Hannon')
+    mimic_mock = Grift::MockMethod.new(Target, :mimic).mock_return_value
+    assert_nil Target.mimic(target, gullible: true)
+    refute_empty mimic_mock.mock.calls
+    assert_equal target, mimic_mock.mock.calls.last.first
+    assert_equal({ gullible: true }, mimic_mock.mock.calls.last.last)
+  end
+
+  def test_it_mocks_a_method_implementation_with_blended_argument_types
+    target = Target.new(first_name: 'Erin', last_name: 'Hannon')
+    mimic_mock = Grift::MockMethod.new(Target, :mimic).mock_implementation do |*_args|
+      return target.full_name
+    end
+    assert_equal 'Hannon', Target.mimic(target, gullible: true)
+    refute_empty mimic_mock.mock.calls
+    assert_equal target, mimic_mock.mock.calls.last.first
+    assert_equal({ gullible: true }, mimic_mock.mock.calls.last.last)
+  end
+
+  def test_it_watches_a_method_with_blended_arguments_types
+    target = Target.new(first_name: 'Erin', last_name: 'Hannon')
+    mimic_mock = Grift::MockMethod.new(Target, :mimic)
+    target_mimic = Target.mimic(target, gullible: true)
+    assert target_mimic.gullible
+    refute_empty mimic_mock.mock.calls
+    assert_equal target, mimic_mock.mock.calls.last.first
+    assert_equal({ gullible: true }, mimic_mock.mock.calls.last.last)
   end
 end


### PR DESCRIPTION
Fixes #64 and closes #60 