### PR TITLE
fix: raise error when mock_implementation receives no block

### DIFF
--- a/lib/grift/mock_method.rb
+++ b/lib/grift/mock_method.rb
@@ -134,6 +134,8 @@ module Grift
     # @return [self] the mock itself
     #
     def mock_implementation(*)
+      raise(Grift::Error, 'Must provide a block for the new implementation') unless block_given?
+
       premock_setup
       mock_executions = @mock_executions # required to access inside class instance block
 

--- a/test/grift/mock_method_test.rb
+++ b/test/grift/mock_method_test.rb
@@ -131,6 +131,12 @@ class MockMethodTest < Minitest::Test
     assert_equal expected_mimic_result, mimic_mock.mock.results.first
   end
 
+  def test_it_raises_error_when_no_block_given_for_mock_implementation
+    assert_raises Grift::Error do
+      Grift.spy_on(Target, :new).mock_implementation
+    end
+  end
+
   def test_returns_mock_executions_type_with_mock_accessor
     target_mock = Grift::MockMethod.new(Target, :full_name, watch: false)
     assert_instance_of Grift::MockMethod::MockExecutions, target_mock.mock


### PR DESCRIPTION
Fixes #76 

Raise an informative `Grift::Error` instead of letting a `LocalJumpError` bubble up.