### PR TITLE
feat: add finite return value mocking

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -102,12 +102,12 @@ Lint/AmbiguousRange:
 
 # Metrics
 Metrics/AbcSize:
-  Max: 20
+  Max: 25
   Exclude:
     - "test/**/*"
 
 Metrics/ClassLength:
-  Max: 150
+  Max: 170
   CountAsOne:
     - array
     - hash

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -141,6 +141,10 @@ Minitest/RefutePredicate:
 Naming/InclusiveLanguage:
   Enabled: true
 
+Naming/MethodParameterName:
+  AllowedNames:
+    - n
+
 Naming/VariableNumber:
   EnforcedStyle: snake_case
 

--- a/lib/grift/mock_method.rb
+++ b/lib/grift/mock_method.rb
@@ -221,6 +221,57 @@ module Grift
     end
 
     ##
+    # Accepts a value and mocks the method to return that value +n+ times instead
+    # of executing its original behavior while mocked. After the method has
+    # been called +n+ times, it will return to its original behavior.
+    #
+    # **IMPORANT:** Calling {#mock_clear} clears the method call history. If it is
+    # called before the nth execution of the mocked method, the method will remain
+    # mocked for another +n+ times.
+    #
+    # @example
+    #   my_mock = Grift.spy_on(String, :upcase).mock_return_value_n_times(2, "BANANA")
+    #   ["apple", "apple", "apple"].map(&:upcase)
+    #   #=> ["BANANA", "BANANA", "APPLE"]
+    #
+    # @example
+    #   my_mock = Grift.spy_on(String, :upcase).mock_return_value_n_times(4, "BANANA")
+    #   ["apple", "apple", "apple"].map(&:upcase)
+    #   #=> ["BANANA", "BANANA", "BANANA"]
+    #   my_mock.mock_clear # clear mock history before 4th (nth) method call
+    #   ["apple", "apple", "apple"].map(&:upcase)
+    #   #=> ["BANANA", "BANANA", "BANANA"]
+    #
+    # @param n [Number] the number of times to mock the return value
+    # @param return_value the value to return from the method +n+ times
+    #
+    # @return [self] the mock itself
+    #
+    def mock_return_value_n_times(n, return_value = nil)
+      premock_setup
+
+      # required to access mock inside class instance block
+      mock_executions = @mock_executions
+      clean_mock = lambda do
+        unmock_method
+        watch_method
+      end
+
+      class_instance.remove_method(@method_name) if !@inherited && method_defined?
+      class_instance.define_method @method_name do |*args, **kwargs|
+        # record the args passed in the call to the method and the result
+        mock_executions.store(args: args, kwargs: kwargs, result: return_value)
+
+        clean_mock.call if mock_executions.count == n
+
+        return_value
+      end
+      class_instance.send(@method_access, @method_name)
+
+      self
+    end
+
+    ##
     # String representation of the MockMethod
     #
     # @see Grift::MockMethod.hash_key

--- a/test/grift/mock_method_test.rb
+++ b/test/grift/mock_method_test.rb
@@ -41,6 +41,44 @@ class MockMethodTest < Minitest::Test
     assert_equal target.first_name, Target.mimic(target).first_name
   end
 
+  def test_it_mocks_an_instance_method_return_value_once
+    true_target_name = 'Michael Scott'
+    mock_target_name = 'Dwight Schrute'
+
+    target = Target.new(first_name: 'Michael', last_name: 'Scott')
+    assert_respond_to target, :full_name
+    assert_equal true_target_name, target.full_name
+
+    full_name_mock = Grift::MockMethod.new(Target, :full_name)
+    full_name_mock.mock_return_value_once(mock_target_name)
+
+    mocked_result = target.full_name
+    assert_equal mock_target_name, mocked_result
+    assert_equal mock_target_name, full_name_mock.mock.results.first
+
+    assert_equal true_target_name, target.full_name
+    assert_equal 2, full_name_mock.mock.results.length
+    assert_equal true_target_name, full_name_mock.mock.results.last
+  end
+
+  def test_it_mocks_a_class_method_return_value_once
+    target = Target.new(first_name: 'Jerry', gullible: false)
+    mock_target = Target.new(first_name: 'Larry')
+    assert_respond_to Target, :mimic
+    assert_equal target.first_name, Target.mimic(target).first_name
+
+    mimic_mock = Grift::MockMethod.new(Target, :mimic)
+    mimic_mock.mock_return_value_once(mock_target)
+
+    mocked_result = Target.mimic(target)
+    refute_equal target.first_name, mocked_result.first_name
+    assert_equal mock_target, mimic_mock.mock.results.first
+
+    assert_equal target.first_name, Target.mimic(target).first_name
+    assert_equal 2, mimic_mock.mock.results.length
+    assert_equal target, mimic_mock.mock.results.last
+  end
+
   def test_it_watches_the_method_by_default
     target_full_name = 'Tobias Funke'
     target = Target.new(first_name: 'Tobias', last_name: 'Funke')

--- a/test/grift/mock_method_test.rb
+++ b/test/grift/mock_method_test.rb
@@ -123,6 +123,64 @@ class MockMethodTest < Minitest::Test
     assert_equal target, mimic_mock.mock.results.last
   end
 
+  def test_it_mocks_an_instance_method_return_values_in_order
+    true_target_name = 'Michael Scott'
+    mock_target_names = ['Dwight Schrute', 'Jim Halpert']
+
+    target = Target.new(first_name: 'Michael', last_name: 'Scott')
+    assert_respond_to target, :full_name
+    assert_equal true_target_name, target.full_name
+
+    full_name_mock = Grift::MockMethod.new(Target, :full_name)
+    full_name_mock.mock_return_values_in_order(mock_target_names)
+
+    mock_target_names.each_with_index do |mock_target_name, i|
+      mocked_result = target.full_name
+      assert_equal mock_target_name, mocked_result
+      assert_equal mock_target_name, full_name_mock.mock.results[i]
+    end
+
+    assert_equal true_target_name, target.full_name
+    assert_equal mock_target_names.length + 1, full_name_mock.mock.results.length
+    assert_equal true_target_name, full_name_mock.mock.results.last
+  end
+
+  def test_it_mocks_a_class_method_return_values_in_order
+    target = Target.new(first_name: 'Jerry', gullible: false)
+    mock_targets = [Target.new(first_name: 'Larry'), Target.new(first_name: 'Gary')]
+    assert_respond_to Target, :mimic
+    assert_equal target.first_name, Target.mimic(target).first_name
+
+    mimic_mock = Grift::MockMethod.new(Target, :mimic)
+    mimic_mock.mock_return_values_in_order(mock_targets)
+
+    mock_targets.each_with_index do |mock_target, i|
+      mocked_result = Target.mimic(target)
+      refute_equal target.first_name, mocked_result.first_name
+      assert_equal mock_target, mimic_mock.mock.results[i]
+    end
+
+    assert_equal target.first_name, Target.mimic(target).first_name
+    assert_equal mock_targets.length + 1, mimic_mock.mock.results.length
+    assert_equal target, mimic_mock.mock.results.last
+  end
+
+  def test_it_raises_error_when_non_array_given_for_mock_return_values_in_order
+    assert_raises Grift::Error do
+      Grift.spy_on(Target, :full_name).mock_return_values_in_order('Gob Bluth')
+    end
+
+    assert_raises Grift::Error do
+      Grift.spy_on(Target, :full_name).mock_return_values_in_order(nil)
+    end
+  end
+
+  def test_it_raises_error_when_empty_array_given_for_mock_return_values_in_order
+    assert_raises Grift::Error do
+      Grift.spy_on(Target, :full_name).mock_return_values_in_order([])
+    end
+  end
+
   def test_it_watches_the_method_by_default
     target_full_name = 'Tobias Funke'
     target = Target.new(first_name: 'Tobias', last_name: 'Funke')

--- a/test/grift/mock_method_test.rb
+++ b/test/grift/mock_method_test.rb
@@ -79,6 +79,50 @@ class MockMethodTest < Minitest::Test
     assert_equal target, mimic_mock.mock.results.last
   end
 
+  def test_it_mocks_an_instance_method_return_value_n_times
+    true_target_name = 'Michael Scott'
+    mock_target_name = 'Dwight Schrute'
+
+    target = Target.new(first_name: 'Michael', last_name: 'Scott')
+    assert_respond_to target, :full_name
+    assert_equal true_target_name, target.full_name
+
+    full_name_mock = Grift::MockMethod.new(Target, :full_name)
+    n = 4
+    full_name_mock.mock_return_value_n_times(n, mock_target_name)
+
+    n.times.each do |i|
+      mocked_result = target.full_name
+      assert_equal mock_target_name, mocked_result
+      assert_equal mock_target_name, full_name_mock.mock.results[i]
+    end
+
+    assert_equal true_target_name, target.full_name
+    assert_equal n + 1, full_name_mock.mock.results.length
+    assert_equal true_target_name, full_name_mock.mock.results.last
+  end
+
+  def test_it_mocks_a_class_method_return_value_n_times
+    target = Target.new(first_name: 'Jerry', gullible: false)
+    mock_target = Target.new(first_name: 'Larry')
+    assert_respond_to Target, :mimic
+    assert_equal target.first_name, Target.mimic(target).first_name
+
+    mimic_mock = Grift::MockMethod.new(Target, :mimic)
+    n = 3
+    mimic_mock.mock_return_value_n_times(n, mock_target)
+
+    n.times.each do |i|
+      mocked_result = Target.mimic(target)
+      refute_equal target.first_name, mocked_result.first_name
+      assert_equal mock_target, mimic_mock.mock.results[i]
+    end
+
+    assert_equal target.first_name, Target.mimic(target).first_name
+    assert_equal n + 1, mimic_mock.mock.results.length
+    assert_equal target, mimic_mock.mock.results.last
+  end
+
   def test_it_watches_the_method_by_default
     target_full_name = 'Tobias Funke'
     target = Target.new(first_name: 'Tobias', last_name: 'Funke')

--- a/test/target.rb
+++ b/test/target.rb
@@ -35,6 +35,14 @@ class Target
     yield
   end
 
+  def ==(other)
+    @first_name == other.first_name &&
+      @last_name == other.last_name &&
+      @gullible == other.gullible &&
+      @knowledge == other.knowledge &&
+      knows_secrets? == other.knows_secrets?
+  end
+
   def self.mimic(target, gullible: false)
     Target.new(first_name: target.first_name, last_name: target.last_name, gullible: gullible)
   end


### PR DESCRIPTION
Adds three methods to allow the finite mocking of return values (rather than indefinite mocking)

* `mock_return_value_once`
* `mock_return_value_n_times`
* `mock_return_values_in_order`

Closes #128 