### PR TITLE
feat: add finite implementation mocking

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,7 +107,7 @@ Metrics/AbcSize:
     - "test/**/*"
 
 Metrics/ClassLength:
-  Max: 190
+  Max: 225
   CountAsOne:
     - array
     - hash

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,7 +107,7 @@ Metrics/AbcSize:
     - "test/**/*"
 
 Metrics/ClassLength:
-  Max: 170
+  Max: 190
   CountAsOne:
     - array
     - hash

--- a/lib/grift/mock_method.rb
+++ b/lib/grift/mock_method.rb
@@ -153,6 +153,52 @@ module Grift
     end
 
     ##
+    # Accepts a block and mocks the method to execute that block instead
+    # of the original behavior the next time the method is called while mocked.
+    # After the method has been called once, it will return to its original
+    # behavior. The method will continue to be watched.
+    #
+    # @see #mock_implementation
+    #
+    # @example
+    #   my_mock = Grift.spy_on(String, :downcase).mock_implementation_once do
+    #       x = 3 + 4
+    #       x.to_s
+    #   end
+    #   ["Banana", "Apple"].map(&:downcase)
+    #   #=> ["7", "apple"]
+    #
+    # @return [self] the mock itself
+    #
+    def mock_implementation_once(*)
+      raise(Grift::Error, 'Must provide a block for the new implementation') unless block_given?
+
+      premock_setup
+
+      # required to access inside class instance block
+      mock_executions = @mock_executions
+      clean_mock = lambda do
+        unmock_method
+        watch_method
+      end
+
+      class_instance.remove_method(@method_name) if !@inherited && method_defined?
+      class_instance.define_method @method_name do |*args, **kwargs|
+        return_value = yield(*args, **kwargs)
+
+        # record the args passed in the call to the method and the result
+        mock_executions.store(args: args, result: return_value)
+
+        clean_mock.call
+
+        return_value
+      end
+      class_instance.send(@method_access, @method_name)
+
+      self
+    end
+
+    ##
     # Accepts a value and mocks the method to return that value instead
     # of executing its original behavior while mocked.
     #
@@ -185,7 +231,8 @@ module Grift
     ##
     # Accepts a value and mocks the method to return that value once instead
     # of executing its original behavior while mocked. After the method has
-    # been called once, it will return to its original behavior.
+    # been called once, it will return to its original behavior. The method
+    # will continue to be watched.
     #
     # @example
     #   my_mock = Grift.spy_on(String, :upcase).mock_return_value_once("BANANA")
@@ -223,7 +270,8 @@ module Grift
     ##
     # Accepts a value and mocks the method to return that value +n+ times instead
     # of executing its original behavior while mocked. After the method has
-    # been called +n+ times, it will return to its original behavior.
+    # been called +n+ times, it will return to its original behavior. The method
+    # will continue to be watched.
     #
     # **IMPORANT:** Calling {#mock_clear} clears the method call history. If it is
     # called before the nth execution of the mocked method, the method will remain
@@ -275,7 +323,7 @@ module Grift
     # Accepts an array of values and mocks the method to return those values
     # in order instead of executing its original behavior while mocked. After
     # the method has been called enough times to return each of the values,
-    # it will return to its original behavior.
+    # it will return to its original behavior. The method continue to be watched.
     #
     # @example
     #   mock_values = ["APPLE", "BANANA", "ORANGE"]

--- a/lib/grift/mock_method.rb
+++ b/lib/grift/mock_method.rb
@@ -199,6 +199,69 @@ module Grift
     end
 
     ##
+    # Accepts a number +n+ and a block and mocks the method to execute that block
+    # instaead of the original behavior the next +n+ times the method is called
+    # while mocked. After the method has been called once, it will return to its
+    # original behavior. The method will continue to be watched.
+    #
+    # **IMPORANT:** Calling {#mock_clear} clears the method call history. If it is
+    # called before the nth execution of the mocked method, the method will remain
+    # mocked for an additonal +n+ calls.
+    #
+    # @see #mock_implementation
+    #
+    # @example
+    #   my_mock = Grift.spy_on(String, :downcase).mock_implementation_n_times(3) do
+    #       x = 3 + 4
+    #       x.to_s
+    #   end
+    #   ["Banana", "Apple", "Orange", "Guava"].map(&:downcase)
+    #   #=> ["7", "7", "7", "guava"]
+    #
+    # @example
+    #   my_mock = Grift.spy_on(String, :downcase).mock_implementation_n_times(5) do
+    #       x = 3 + 4
+    #       x.to_s
+    #   end
+    #   ["Banana", "Apple", "Orange", "Guava"].map(&:downcase)
+    #   #=> ["7", "7", "7", "7"]
+    #   my_mock.mock_clear # clear mock history before 5th (nth) method call
+    #   ["Banana", "Apple", "Orange", "Guava"].map(&:downcase)
+    #   #=> ["7", "7", "7", "7"]
+    #
+    # @param n [Number] the number of times to mock the implementation
+    #
+    # @return [self] the mock itself
+    #
+    def mock_implementation_n_times(n, *)
+      raise(Grift::Error, 'Must provide a block for the new implementation') unless block_given?
+
+      premock_setup
+
+      # required to access inside class instance block
+      mock_executions = @mock_executions
+      clean_mock = lambda do
+        unmock_method
+        watch_method
+      end
+
+      class_instance.remove_method(@method_name) if !@inherited && method_defined?
+      class_instance.define_method @method_name do |*args, **kwargs|
+        return_value = yield(*args, **kwargs)
+
+        # record the args passed in the call to the method and the result
+        mock_executions.store(args: args, result: return_value)
+
+        clean_mock.call if mock_executions.count == n
+
+        return_value
+      end
+      class_instance.send(@method_access, @method_name)
+
+      self
+    end
+
+    ##
     # Accepts a value and mocks the method to return that value instead
     # of executing its original behavior while mocked.
     #
@@ -275,7 +338,7 @@ module Grift
     #
     # **IMPORANT:** Calling {#mock_clear} clears the method call history. If it is
     # called before the nth execution of the mocked method, the method will remain
-    # mocked for another +n+ times.
+    # mocked for an additional +n+ calls.
     #
     # @example
     #   my_mock = Grift.spy_on(String, :upcase).mock_return_value_n_times(2, "BANANA")

--- a/test/grift/mock_method_test.rb
+++ b/test/grift/mock_method_test.rb
@@ -272,6 +272,29 @@ class MockMethodTest < Minitest::Test
     assert_equal target_full_name, full_name_mock.mock.results.last
   end
 
+  def test_it_mocks_an_instance_method_implementation_n_times
+    target_full_name = 'Buster Bluth'
+    target = Target.new(first_name: 'Buster', last_name: 'Bluth')
+    assert_respond_to target, :full_name
+    assert_equal target_full_name, target.full_name
+
+    full_name_mock = Grift::MockMethod.new(Target, :full_name)
+    n = 3
+    full_name_mock.mock_implementation_n_times(n) do
+      [target.last_name, target.first_name].join(' ')
+    end
+
+    expected_full_name_result = target_full_name.split.reverse.join(' ')
+    n.times.each do |i|
+      assert_equal expected_full_name_result, target.full_name
+      assert_equal expected_full_name_result, full_name_mock.mock.results[i]
+    end
+
+    assert_equal target_full_name, target.full_name
+    assert_equal n + 1, full_name_mock.mock.count
+    assert_equal target_full_name, full_name_mock.mock.results.last
+  end
+
   def test_it_mocks_a_class_method_implementation
     target = Target.new(first_name: 'Jerry')
     assert_respond_to Target, :mimic
@@ -310,6 +333,30 @@ class MockMethodTest < Minitest::Test
     assert_equal target, mimic_mock.mock.results.last
   end
 
+  def test_it_mocks_a_class_method_implementation_n_times
+    target = Target.new(first_name: 'Jerry')
+    assert_respond_to Target, :mimic
+    assert_equal target.first_name, Target.mimic(target).first_name
+
+    mimic_mock = Grift::MockMethod.new(Target, :mimic)
+    n = 4
+    mimic_mock.mock_implementation_n_times(n) do |t|
+      t.full_name * 2
+    end
+
+    n.times.each do |i|
+      mocked_result = Target.mimic(target, gullible: true)
+      expected_mimic_result = target.full_name * 2
+      assert_equal expected_mimic_result, mocked_result
+      assert_equal expected_mimic_result, mimic_mock.mock.results[i]
+    end
+
+    unmocked_result = Target.mimic(target, gullible: true)
+    assert_equal target, unmocked_result
+    assert_equal n + 1, mimic_mock.mock.count
+    assert_equal target, mimic_mock.mock.results.last
+  end
+
   def test_it_raises_error_when_no_block_given_for_mock_implementation
     assert_raises Grift::Error do
       Grift.spy_on(Target, :new).mock_implementation
@@ -319,6 +366,12 @@ class MockMethodTest < Minitest::Test
   def test_it_raises_error_when_no_block_given_for_mock_implementation_once
     assert_raises Grift::Error do
       Grift.spy_on(Target, :new).mock_implementation_once
+    end
+  end
+
+  def test_it_raises_error_when_no_block_given_for_mock_implementation_n_times
+    assert_raises Grift::Error do
+      Grift.spy_on(Target, :new).mock_implementation_n_times(10)
     end
   end
 


### PR DESCRIPTION
Adds two methods to allow the finite mocking of implementations (rather than indefinite mocking)

- `mock_implementation_once`
- `mock_implementation_n_times`

Closes #129 